### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -1,5 +1,9 @@
 name: Dependency Update
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   schedule:
     # Run every Monday at 9 AM UTC


### PR DESCRIPTION
Potential fix for [https://github.com/ysnarafat/fin-track/security/code-scanning/3](https://github.com/ysnarafat/fin-track/security/code-scanning/3)

To resolve this problem, we should explicitly declare a `permissions` block that reflects the minimal privileges required for the workflow to function correctly. 

- The typical minimal permissions for workflows that only check out code and report are `contents: read`.
- However, since the workflow also creates pull requests (see the step using `peter-evans/create-pull-request`), it needs write permission for pull requests (`pull-requests: write`).
- It is best to add the permissions block at the top level of the workflow (before `jobs:`) so it applies to all jobs, unless a job requires further specialized permissions (which this workflow does not).

**Change to make:**  
At the start of `.github/workflows/dependency-update.yml`, insert a `permissions` key with the following permissions:
```yaml
permissions:
  contents: read
  pull-requests: write
```
This should come after the `name` and before (or after) the `on:` trigger as appropriate (either position is valid).

No dependencies or further code changes are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
