### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/ysnarafat/fin-track/security/code-scanning/2](https://github.com/ysnarafat/fin-track/security/code-scanning/2)

To fix the CodeQL-flagged issue, add a `permissions:` block specifying least privilege, either at the top level of the workflow or within the job. The simplest and recommended way is to add a top-level `permissions:` key just beneath the workflow `name`, before the `on:` block. For this workflow, `contents: read` covers reading repository files, and steps such as checkout and caching do not require write permissions. If there is a need for additional permissions in the future (such as to interact with issues or pull requests), those types can be added.  
Change needed:  
- Edit `.github/workflows/ci.yml`  
- Insert after `name: CI`, before the `on:` block:  
  ```
  permissions:
    contents: read
  ```
No additional imports or definitions are required since this is a YAML workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
