### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-setup.yml
+++ b/.github/workflows/test-setup.yml
@@ -1,3 +1,4 @@
+permissions: none
 name: Test Setup
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/ysnarafat/fin-track/security/code-scanning/1](https://github.com/ysnarafat/fin-track/security/code-scanning/1)

To address the problem, we should add an explicit `permissions` block to restrict the `GITHUB_TOKEN` to the minimum necessary access. Since this workflow does not seem to use any GitHub API actions (such as interacting with issues, PRs, or contents), the least privilege required is generally `permissions: none`. This can be set at the workflow level (globally) at the top of `.github/workflows/test-setup.yml`. Place the `permissions` key just after the `name` (and before `on:`), so that it takes effect for all jobs unless overridden. No imports or additional definitions are needed; the edit is a simple insertion in the YAML frontmatter.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
